### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Snorlax currently supports the following platforms:
 
 Using the following Package Managers:
 
-- [Cocoapods](https://cocoapods.org/)
+- [CocoaPods](https://cocoapods.org/)
 - [Carthage](https://github.com/Carthage/Carthage)
 - [Swift Package Manager](https://swift.org/package-manager/)
 - Adding as an Xcode Subproject
@@ -44,13 +44,13 @@ Sure, use your favorite package manager. Please note the two different versions:
 
 You can see examples at [Snorlax Samples](https://github.com/jeffh/SnorlaxSamples)
 
-Cocoapods
+CocoaPods
 ---------
 
 Add Snorlax to your pod file and run `pod install`:
 
 ```ruby
-# Cocoapods
+# CocoaPods
 pod 'Snorlax', '~> 0.1.0'
 ```
 


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
